### PR TITLE
Remove welcome screen button

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,8 +29,6 @@
                     group-id="ProjectView.ToolWindow.SecondaryActions"
                     relative-to-action="ProjectView.FoldIgnoredFiles"
                     anchor="before"/>
-            <add-to-group group-id="WelcomeScreen.QuickStart" anchor="first"/>
-
         </action>
         <action id="ProjectView.FoldIgnoredFiles"
                 class="com.pj.foldableprojectview.actionSystem.FoldIgnoredFilesAction"


### PR DESCRIPTION
Seems like a debug line to ensure the button is working but hides the `Get from VCS` button.

Before:
![image](https://github.com/user-attachments/assets/50da01db-fdc8-41ff-af34-f13fd3687b85)

After: (WebStorm have my pull-requested patch installed)
![image](https://github.com/user-attachments/assets/c68579e4-0484-49db-8011-f6ea01da166f)
